### PR TITLE
Create nested folders for MasterDoc

### DIFF
--- a/NotebookML_MasterDoc.gs
+++ b/NotebookML_MasterDoc.gs
@@ -118,18 +118,36 @@ function rebuildQueueFromRoot_(){
 
 /***** マスターDoc ID の永続化（フォルダ単位） **********************************/
 function getMasterIdKey_(folderId){ return `MASTER_DOC_${folderId}`; }
-function getOrCreateMasterDocForFolder_(folderId, folderName){
+function getOrCreateMasterDocForFolder_(folderId, folderName, folderPath){
+  // folderId は URL/ID どちらでも受け付ける
+  folderId = getIdFromUrlOrId_(folderId);
+  if(!folderId) throw new Error('folderId is required');
   const props=PropertiesService.getScriptProperties();
-  const saved=props.getProperty(getMasterIdKey_(folderId));
+  const key=getMasterIdKey_(folderId);
+  const saved=props.getProperty(key);
+  let masterId;
   try{
-    if(saved){ DocumentApp.openById(saved); return saved; }
+    if(saved){ DocumentApp.openById(saved); masterId = saved; }
   }catch(e){ /* 落ちていたら作り直し */ }
-  const dest=getFolderByUrlOrId_(DEST_FOLDER_INPUT);
-  const name = `NotebookLM_Master_${folderName}`;
-  const doc  = DocumentApp.create(name);
-  DriveApp.getFileById(doc.getId()).moveTo(dest);
-  props.setProperty(getMasterIdKey_(folderId), doc.getId());
-  return doc.getId();
+
+  // 保存先のフォルダ階層を folderPath の第3階層まで作成
+  const destRoot=getFolderByUrlOrId_(DEST_FOLDER_INPUT);
+  const segments=String(folderPath||'').split('/').slice(0,-1).slice(0,3);
+  let destFolder=destRoot;
+  for(const name of segments){
+    const it=destFolder.getFoldersByName(name);
+    destFolder = it.hasNext() ? it.next() : destFolder.createFolder(name);
+  }
+
+  if(!masterId){
+    const name = `NotebookLM_Master_${folderName}`;
+    const doc  = DocumentApp.create(name);
+    masterId = doc.getId();
+    props.setProperty(key, masterId);
+  }
+
+  DriveApp.getFileById(masterId).moveTo(destFolder);
+  return masterId;
 }
 
 /***** Googleドキュメントの本文を取得（上限考慮） ******************************/
@@ -144,8 +162,11 @@ function fetchDocText_(docId){
 
 /***** フォルダ1件を処理（Queue から呼ばれる中核） *****************************/
 function buildOrUpdateMasterForSingleFolder(folderId, folderPath, folderName, opt={}){
+  // folderId は URL/ID どちらでも受け付ける
+  folderId = getIdFromUrlOrId_(folderId);
+  if(!folderId) throw new Error('folderId is required');
   const folder = DriveApp.getFolderById(folderId);
-  const masterId = getOrCreateMasterDocForFolder_(folderId, folderName);
+  const masterId = getOrCreateMasterDocForFolder_(folderId, folderName, folderPath);
   const master   = DocumentApp.openById(masterId);
   const body     = master.getBody();
   // クリア


### PR DESCRIPTION
## Summary
- Generate MasterDoc within a folder hierarchy up to three levels deep based on `folderPath`
- Sanitize and validate folder IDs before processing to avoid `Invalid argument: folderId` errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be897c64208328afc77c57fc86418e